### PR TITLE
Add vcpkg support on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ cc         = "1.0"
 pkg-config = "0.3"
 bindgen    = "0.54"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"
+
 [features]
 default  = ["avcodec", "avdevice", "avfilter", "avformat", "swresample", "swscale"]
 

--- a/build.rs
+++ b/build.rs
@@ -612,8 +612,7 @@ fn main() {
         );
         link_to_libraries(statik);
         vec![ffmpeg_dir.join("include")]
-    }
-    else if let Some(paths) = try_vcpkg() {
+    } else if let Some(paths) = try_vcpkg() {
         let is_vcpkg_static = env::var_os("VCPKGRS_DYNAMIC").is_none();
         if is_vcpkg_static != statik {
             panic!(


### PR DESCRIPTION
Build steps:
1. install llvm (required for [bindgen](https://rust-lang.github.io/rust-bindgen/requirements.html#windows))
2. install [vcpkg](https://docs.microsoft.com/en-us/cpp/build/vcpkg?view=vs-2019#installation)
3. install ffmpeg via vcpkg:
`$ vcpkg install ffmpeg:x64-windows-static-md` for static libraries, enable "static" feature for ffmpeg-sys
`$ vcpkg install ffmpeg:x64-windows` for dlls, define VCPKGRS_DYNAMIC environment variable
See [this](https://docs.rs/vcpkg/0.2.10/vcpkg/index.html#static-vs-dynamic-linking) section of vcpkg-rs docs for more info on static vs dynamic linkage.
5. run `cargo build`