### PR TITLE
Check for FFMPEG_DIR in environment.json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ num_cpus   = "1.11"
 cc         = "1.0"
 pkg-config = "0.3"
 bindgen    = { version = "0.54", default-features = false, features = ["runtime"] }
+serde_json = "1.0"
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
While I've been looking to use this project I found it surprisingly difficult to find any practical way of configuring Visual Studio
Code so that that FFMPEG_DIR could be set in the environment when it runs cargo as part of its rust-analyzer/RLE integration
for editor diagnostics.

Looking into this further I found others had been struggling for a long time with similar issues:

rust-lang/cargo#97
rust-lang/cargo#4121
rust-lang/rls#915
https://github.com/rust-lang/vscode-rust/issues/791
https://stackoverflow.com/questions/57017066/how-do-i-set-environment-variables-with-cargo

Notably rust-lang/cargo#4121 was filed back in 2017 for essentially this same problem but in all that time there's been no traction in finding a good solution for this.

Considering this impracticality, this adds support for an alternative `environment.json` file that can be created like:

```json
{
    "FFMPEG_DIR": "/path/to/ffmpeg-build/"
}
```

The change is backwards compatible, since the file isn't required and it will also still check for the environment variable

Addresses: rust-lang/cargo#4121