### PR TITLE
bump bindgen to 0.56 to fix build on aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2"
 num_cpus   = "1.11"
 cc         = "1.0"
 pkg-config = "0.3"
-bindgen    = { version = "0.54", default-features = false, features = ["runtime"] }
+bindgen    = { version = "0.56", default-features = false, features = ["runtime"] }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 vcpkg = "0.2"


### PR DESCRIPTION
My aarch64 machine does not compile this crate with bindgen 0.54 - libclang panics in bindgen. Bumping to 0.56 fixes this behaviour