### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ keywords    = ["audio", "video"]
 doctest = false
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.88"
 
 [build-dependencies]
-num_cpus   = "1.11"
-cc         = "1.0"
-pkg-config = "0.3"
-bindgen    = { version = "0.54", default-features = false, features = ["runtime"] }
+num_cpus   = "1.13.0"
+cc         = "1.0.67"
+pkg-config = "0.3.19"
+bindgen    = { version = "0.57.0", default-features = false, features = ["runtime"] }
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
-vcpkg = "0.2"
+vcpkg = "0.2.11"
 
 [features]
 default  = ["avcodec", "avdevice", "avfilter", "avformat", "swresample", "swscale"]


### PR DESCRIPTION
Also bumps minor versions of other deps, because the actual .0 versions aren't actively tested, and usually break when something like `-Z minimal-versions` is used.