### PR TITLE
Add libdav1d and libvmaf support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ build-lib-opencv     = ["build"]
 # encoders/decoders
 build-lib-aacplus          = ["build"]
 build-lib-celt             = ["build"]
+build-lib-dav1d            = ["build"]
 build-lib-dcadec           = ["build"]
 build-lib-faac             = ["build"]
 build-lib-fdk-aac          = ["build"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ build-lib-ass        = ["build"]
 build-lib-freetype   = ["build"]
 build-lib-freebidi   = ["build"]
 build-lib-opencv     = ["build"]
+build-lib-vmaf       = ["build"]
 
 # encoders/decoders
 build-lib-aacplus          = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -284,6 +284,7 @@ fn build() -> io::Result<()> {
     enable!(configure, "BUILD_LIB_FREETYPE", "libfreetype");
     enable!(configure, "BUILD_LIB_FRIBIDI", "libfribidi");
     enable!(configure, "BUILD_LIB_OPENCV", "libopencv");
+    enable!(configure, "BUILD_LIB_VMAF", "libvmaf");
 
     // configure external encoders/decoders
     enable!(configure, "BUILD_LIB_AACPLUS", "libaacplus");

--- a/build.rs
+++ b/build.rs
@@ -289,6 +289,7 @@ fn build() -> io::Result<()> {
     enable!(configure, "BUILD_LIB_AACPLUS", "libaacplus");
     enable!(configure, "BUILD_LIB_CELT", "libcelt");
     enable!(configure, "BUILD_LIB_DCADEC", "libdcadec");
+    enable!(configure, "BUILD_LIB_DAV1D", "libdav1d");
     enable!(configure, "BUILD_LIB_FAAC", "libfaac");
     enable!(configure, "BUILD_LIB_FDK_AAC", "libfdk-aac");
     enable!(configure, "BUILD_LIB_GSM", "libgsm");


### PR DESCRIPTION
We would like to use these libraries with static builds in av1an, so this PR adds support for them.