### PR TITLE
Fix build on big-endian architectures

### DIFF
--- a/src/avutil/pixfmt.rs
+++ b/src/avutil/pixfmt.rs
@@ -35,6 +35,7 @@ pub const AV_PIX_FMT_BGR555: AVPixelFormat = AV_PIX_FMT_BGR555LE;
 #[cfg(target_endian = "little")]
 pub const AV_PIX_FMT_BGR444: AVPixelFormat = AV_PIX_FMT_BGR444LE;
 
+#[cfg(target_endian = "little")]
 pub const AV_PIX_FMT_YUV420P9: AVPixelFormat = AV_PIX_FMT_YUV420P9LE;
 #[cfg(target_endian = "little")]
 pub const AV_PIX_FMT_YUV422P9: AVPixelFormat = AV_PIX_FMT_YUV422P9LE;


### PR DESCRIPTION
```
error[E0428]: the name `AV_PIX_FMT_YUV420P9` is defined multiple times
   --> /wrkdirs/usr/ports/multimedia/av1an/work/Av1an-0.2.0/cargo-crates/ffmpeg-sys-next-4.4.0/src/avutil/pixfmt.rs:155:1
    |
38  | pub const AV_PIX_FMT_YUV420P9: AVPixelFormat = AV_PIX_FMT_YUV420P9LE;
    | --------------------------------------------------------------------- previous definition of the value `AV_PIX_FMT_YUV420P9` here
...
155 | pub const AV_PIX_FMT_YUV420P9: AVPixelFormat = AV_PIX_FMT_YUV420P9BE;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `AV_PIX_FMT_YUV420P9` redefined here
    |
    = note: `AV_PIX_FMT_YUV420P9` must be defined only once in the value namespace of this module
```