### PR TITLE
Added V4L2 support to the library to help working with "/dev/videoX" devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,7 @@ name: build
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+  
 jobs:
   build-test-lint:
     name: FFmpeg ${{ matrix.ffmpeg_version }} - build, test and lint
@@ -14,7 +13,7 @@ jobs:
         ffmpeg_version: ['3.3', '3.4', '4.0', '4.1', '4.2', '4.3', '4.4', '5.0']
       fail-fast: false
     env:
-      FEATURES: avcodec,avdevice,avfilter,avformat,postproc,swresample,swscale
+      FEATURES: avcodec,avdevice,avfilter,avformat,postproc,swresample,swscale,v4l2
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: build
 on:
   push:
   pull_request:
-  
+  schedule:
+    - cron: "0 0 * * *"
+
 jobs:
   build-test-lint:
     name: FFmpeg ${{ matrix.ffmpeg_version }} - build, test and lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-sys-next"
-version = "5.0.1"
+version = "5.0.2"
 build   = "build.rs"
 links   = "ffmpeg"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bindgen    = { version = "0.59", default-features = false, features = ["runtime"
 vcpkg = "0.2"
 
 [features]
-default  = ["avcodec", "avdevice", "avfilter", "avformat", "swresample", "swscale"]
+default  = ["avcodec", "avdevice", "avfilter", "avformat", "swresample", "swscale", "v4l2"]
 
 static = []
 build  = ["static"]
@@ -106,3 +106,4 @@ avresample = []
 postproc   = []
 swresample = []
 swscale    = []
+v4l2       = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-sys-next"
-version = "5.0.2"
+version = "5.0.1"
 build   = "build.rs"
 links   = "ffmpeg"
 

--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,10 @@ impl Library {
 
 static LIBRARIES: &[Library] = &[
     Library {
+        name: "v4l2",
+        is_feature: true,
+    },
+    Library {
         name: "avcodec",
         is_feature: true,
     },
@@ -79,13 +83,13 @@ impl ParseCallbacks for Callbacks {
         let codec_flag_prefix = "AV_CODEC_FLAG_";
         let error_max_size = "AV_ERROR_MAX_STRING_SIZE";
 
-        if value >= i64::min_value() as i64
-            && value <= i64::max_value() as i64
+        if value >= i64::MIN as i64
+            && value <= i64::MAX as i64
             && _name.starts_with(ch_layout_prefix)
         {
             Some(IntKind::ULongLong)
-        } else if value >= i32::min_value() as i64
-            && value <= i32::max_value() as i64
+        } else if value >= i32::MIN as i64
+            && value <= i32::MAX as i64
             && (_name.starts_with(codec_cap_prefix) || _name.starts_with(codec_flag_prefix))
         {
             Some(IntKind::UInt)
@@ -94,7 +98,7 @@ impl ParseCallbacks for Callbacks {
                 name: "usize",
                 is_signed: false,
             })
-        } else if value >= i32::min_value() as i64 && value <= i32::max_value() as i64 {
+        } else if value >= i32::MIN as i64 && value <= i32::MAX as i64 {
             Some(IntKind::Int)
         } else {
             None
@@ -347,6 +351,7 @@ fn build() -> io::Result<()> {
     let output = configure
         .output()
         .unwrap_or_else(|_| panic!("{:?} failed", configure));
+
     if !output.status.success() {
         println!("configure: {}", String::from_utf8_lossy(&output.stdout));
 


### PR DESCRIPTION
Current implementation doesn't support opening `/dev/videoX` devices. This patch enables V4L2 compilation to support that.