### PR TITLE
Added bsf headers on ffmpeg 5+

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1177,8 +1177,11 @@ fn main() {
             .header(search_include(&include_paths, "libavcodec/vorbis_parser.h"));
 
         if ffmpeg_major_version >= 5 {
-            builder = builder.header(search_include(&include_paths, "libavcodec/bsf.h"))
+            if let Some(bsf_header) = maybe_search_include(&include_paths, "libavcodec/bsf.h") {
+                builder = builder.header(bsf_header);
+            }
         }
+
         if ffmpeg_major_version < 5 {
             builder = builder.header(search_include(&include_paths, "libavcodec/vaapi.h"))
         }

--- a/build.rs
+++ b/build.rs
@@ -1176,6 +1176,9 @@ fn main() {
             .header(search_include(&include_paths, "libavcodec/avfft.h"))
             .header(search_include(&include_paths, "libavcodec/vorbis_parser.h"));
 
+        if ffmpeg_major_version >= 5 {
+            builder = builder.header(search_include(&include_paths, "libavcodec/bsf.h"))
+        }
         if ffmpeg_major_version < 5 {
             builder = builder.header(search_include(&include_paths, "libavcodec/vaapi.h"))
         }


### PR DESCRIPTION
The bitstreamfilters have moved in ffmpeg 5 to a separate header. This PR adds that header (conditionally on ffmpeg 5+) to the bindings.