### PR TITLE
Add feature to mark generated enums as non-exhaustive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,13 @@ bindgen    = { version = "0.59", default-features = false, features = ["runtime"
 vcpkg = "0.2"
 
 [features]
-default  = ["avcodec", "avdevice", "avfilter", "avformat", "swresample", "swscale"]
+default  = ["avcodec", "avdevice", "avfilter", "avformat", "swresample", "swscale", "non-exhaustive-enums"]
 
 static = []
 build  = ["static"]
+
+# mark enums in generated bindings as #[non_exhaustive]
+non-exhaustive-enums = []
 
 # licensing
 build-license-gpl      = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -1167,7 +1167,7 @@ fn main() {
         .blocklist_function("y1l")
         .blocklist_function("ynl")
         .opaque_type("__mingw_ldbl_type_t")
-        .rustified_enum("*")
+        .rustified_non_exhaustive_enum("*")
         .prepend_enum_name(false)
         .derive_eq(true)
         .size_t_is_usize(true)

--- a/build.rs
+++ b/build.rs
@@ -1167,11 +1167,16 @@ fn main() {
         .blocklist_function("y1l")
         .blocklist_function("ynl")
         .opaque_type("__mingw_ldbl_type_t")
-        .rustified_non_exhaustive_enum("*")
         .prepend_enum_name(false)
         .derive_eq(true)
         .size_t_is_usize(true)
         .parse_callbacks(Box::new(Callbacks));
+
+    if env::var("CARGO_FEATURE_NON_EXHAUSTIVE_ENUMS").is_ok() {
+        builder = builder.rustified_non_exhaustive_enum("*");
+    } else {
+        builder = builder.rustified_enum("*");
+    }
 
     // The input headers we would like to generate
     // bindings for.


### PR DESCRIPTION
Closes #46.

This is a simple change. Enabling the feature adds the `#[non_exhaustive]` attribute to the generated enums (and nothing else). What this means for libraries/applications downstream is explained in the linked issue.

I'll explain why I think this should be a feature and not "always-on" in the corresponding PR against ffmpeg-next.