### PR TITLE
Fix version check for ffmpeg 6.0

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -587,7 +587,7 @@ fn check_features(
         ("ffmpeg_4_4", 58, 100),
         ("ffmpeg_5_0", 59, 18),
         ("ffmpeg_5_1", 59, 37),
-        ("ffmpeg_6_0", 60, 4),
+        ("ffmpeg_6_0", 60, 3),
     ];
     for &(ffmpeg_version_flag, lavc_version_major, lavc_version_minor) in
         ffmpeg_lavc_versions.iter()


### PR DESCRIPTION
It appears the the 6.0 release has 60.3 lavc version. I made a mistake in the previous PR, looks like I based it on the master branch instead of release/6.0 and they already increased the version to 60.4 so it didn't work. I now confirmed it builds correctly with this change.