### PR TITLE
Explicitly enable cross-compilation in ./configure

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -198,7 +198,11 @@ fn build() -> io::Result<()> {
 
     configure.arg(format!("--prefix={}", search().to_string_lossy()));
 
-    if env::var("TARGET").unwrap() != env::var("HOST").unwrap() {
+    let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
+    if target != host {
+        configure.arg("--enable-cross-compile");
+
         // Rust targets are subtly different than naming scheme for compiler prefixes.
         // The cc crate has the messy logic of guessing a working prefix,
         // and this is a messy way of reusing that logic.

--- a/build.rs
+++ b/build.rs
@@ -207,6 +207,14 @@ fn build() -> io::Result<()> {
         // The cc crate has the messy logic of guessing a working prefix,
         // and this is a messy way of reusing that logic.
         let cc = cc::Build::new();
+
+        // Apple-clang needs this, -arch is not enough.
+        let target_flag = format!("--target={}", target);
+        if cc.is_flag_supported(&target_flag).unwrap_or(false) {
+            configure.arg(format!("--extra-cflags={}", target_flag));
+            configure.arg(format!("--extra-ldflags={}", target_flag));
+        }
+
         let compiler = cc.get_compiler();
         let compiler = compiler.path().file_stem().unwrap().to_str().unwrap();
         let suffix_pos = compiler.rfind('-').unwrap(); // cut off "-gcc"


### PR DESCRIPTION
The configure script wants this, otherwise it won't configure itself properly for cross-compilation on all platforms.