### PR TITLE
tell cargo we're using FFMPEG_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -643,6 +643,8 @@ fn link_to_libraries(statik: bool) {
 }
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=FFMPEG_DIR");
+
     let statik = env::var("CARGO_FEATURE_STATIC").is_ok();
     let ffmpeg_major_version: u32 = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
 


### PR DESCRIPTION
Avoid bad caches and unnecessary `cargo clean` calls