### PR TITLE
fix: Missing extra libs linker flags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -243,6 +243,7 @@ fn build() -> io::Result<()> {
     // make it static
     configure.arg("--enable-static");
     configure.arg("--disable-shared");
+    configure.arg("--enable-pthreads");
 
     configure.arg("--enable-pic");
 
@@ -681,20 +682,50 @@ fn main() {
             let config_mak = source().join("ffbuild/config.mak");
             let file = File::open(config_mak).unwrap();
             let reader = BufReader::new(file);
-            let extra_libs = reader
+            let extra_linker_args = reader
                 .lines()
-                .find(|line| line.as_ref().unwrap().starts_with("EXTRALIBS"))
-                .map(|line| line.unwrap())
-                .unwrap();
+                .filter_map(|line| {
+                    let line = line.as_ref().ok()?;
 
-            let linker_args = extra_libs.split('=').last().unwrap().split(' ');
-            let include_libs = linker_args
-                .filter(|v| v.starts_with("-l"))
-                .map(|flag| &flag[2..]);
+                    if line.starts_with("EXTRALIBS") {
+                        Some(
+                            line.split('=')
+                                .last()
+                                .unwrap()
+                                .split(' ')
+                                .map(|s| s.to_string())
+                                .collect::<Vec<_>>(),
+                        )
+                    } else {
+                        None
+                    }
+                })
+                .flatten()
+                .collect::<Vec<_>>();
 
-            for lib in include_libs {
-                println!("cargo:rustc-link-lib={}", lib);
-            }
+            extra_linker_args
+                .iter()
+                .filter(|flag| flag.starts_with("-l"))
+                .map(|lib| &lib[2..])
+                .for_each(|lib| println!("cargo:rustc-link-lib={}", lib));
+
+            extra_linker_args
+                .iter()
+                .filter(|v| v.starts_with("-L"))
+                .map(|flag| {
+                    let path = &flag[2..];
+                    if path.starts_with('/') {
+                        PathBuf::from(path)
+                    } else {
+                        source().join(path)
+                    }
+                })
+                .for_each(|lib_search_path| {
+                    println!(
+                        "cargo:rustc-link-search=native={}",
+                        lib_search_path.to_str().unwrap()
+                    );
+                })
         }
 
         vec![search().join("include")]
@@ -1336,4 +1367,8 @@ fn main() {
     bindings
         .write_to_file(output().join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    unsafe {
+        env::set_var("FFMPEG_SYS_INCLUDE_PATH", include_paths.first().unwrap());
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1367,8 +1367,4 @@ fn main() {
     bindings
         .write_to_file(output().join("bindings.rs"))
         .expect("Couldn't write bindings!");
-
-    unsafe {
-        env::set_var("FFMPEG_SYS_INCLUDE_PATH", include_paths.first().unwrap());
-    }
 }


### PR DESCRIPTION
this should resolve issues like https://github.com/zmwangx/rust-ffmpeg-sys/issues/69

ffmpeg .mak file can look like this when there are a lot of linked flags for different libraries but now ffmpeg only reads the main EXTRALIBS= while the other libs are ignored.

After this change it flat maps over all of the extralibs (I also added support for -L flags) and everything works semlessly

```
EXTRALIBS=
...
EXTRALIBS-avdevice=-lm
EXTRALIBS-avfilter=-pthread -lm
EXTRALIBS-swscale=-lm
EXTRALIBS-postproc=-lm
EXTRALIBS-avformat=-lm
EXTRALIBS-avcodec=-pthread -lm -lmp3lame -lm -L/opt/homebrew/Cellar/x264/r3108/lib -lx264 -L/opt/homebrew/Cellar/x265/3.6/lib -lx265
EXTRALIBS-swresample=-lm
EXTRALIBS-avutil=-pthread -lm -framework CoreFoundation -framework CoreVideo -framework CoreMedia
EXTRALIBS-ffplay=
EXTRALIBS-ffprobe=
EXTRALIBS-ffmpeg=
EXTRALIBS-cpu_init=-pthread
EXTRALIBS-cws2fws=
```