### PR TITLE
feat: Hardware accelleration build options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,16 @@ build-lib-x265             = ["build"]
 build-lib-avs              = ["build"]
 build-lib-xvid             = ["build"]
 
+build-hardcoded-tables     = ["build"]
+
+# hardware accelleration
+build-nvidia-hwacc =  ["build"]
+build-videotoolbox =  ["build"]
+build-audiotoolbox =  ["build"]
+buid-vaapi =          ["build"]
+build-opencl =        ["build"]
+build-vulkan =        ["build"]
+
 # protocols
 build-lib-smbclient = ["build"]
 build-lib-ssh       = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -236,6 +236,23 @@ fn build() -> io::Result<()> {
         configure.arg(format!("--target_os={}", get_ffmpet_target_os()));
     }
 
+    // for ios specific hardware acceleration ffmpeg needs to find the frameworks
+    // and link against them using -framework
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("ios") {
+        let output = Command::new("xcrun")
+            .args(["--sdk", "iphoneos", "--show-sdk-path"])
+            .output()
+            .expect("failed to run xcrun")
+            .stdout;
+
+        configure.arg(format!(
+            "--sysroot={}",
+            str::from_utf8(&output)
+                .expect("Failed to parse xcrun output")
+                .trim()
+        ));
+    }
+
     // control debug build
     if env::var("DEBUG").is_ok() {
         configure.arg("--enable-debug");
@@ -347,6 +364,29 @@ fn build() -> io::Result<()> {
     enable!(configure, "BUILD_LIB_X265", "libx265");
     enable!(configure, "BUILD_LIB_AVS", "libavs");
     enable!(configure, "BUILD_LIB_XVID", "libxvid");
+
+    // hardware accelleration
+    enable!(configure, "BUILD_VAAPI", "vaapi");
+    enable!(configure, "BUILD_VULKAN", "vdpau");
+    enable!(configure, "BUILD_OPENCL", "vaapi");
+
+    if env::var("CARGO_FEATURE_BUILD_VIDEOTOOLBOX").is_ok() {
+        configure.arg("--enable-videotoolbox");
+        configure.arg("--extra-cflags=-mios-version-min=11.0");
+    }
+
+    if env::var("CARGO_FEATURE_BUILD_AUDIOTOOLBOX").is_ok() {
+        configure.arg("--enable-audiotoolbox");
+        configure.arg("--extra-cflags=-mios-version-min=11.0");
+    }
+
+    if env::var("CARGO_FEATURE_BUILD_NVIDIA_HWACC").is_ok() {
+        configure.arg("--enable-cuda-nvcc");
+        configure.arg("--enable-cuvid");
+        configure.arg("--enable-nvenc");
+        configure.arg("--enable-nvdec");
+        configure.arg("--enable-libnpp");
+    }
 
     // other external libraries
     enable!(configure, "BUILD_LIB_DRM", "libdrm");


### PR DESCRIPTION
This PR adds 2 well-tested by my hardware accelleration platforms: Native apple video- & audiotoolbox and Nvidia CUDA.

nvidia cuda is a little bit weird cause it always require at least 3 flags to be build and there is no reason to separate them so I decided to have one feature flag at least here instead