### PR TITLE
Static linking with latest ffmpeg fails with link errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -783,6 +783,8 @@ fn main() {
             // avutil depdendencies
             println!("cargo:rustc-link-lib=bcrypt");
             println!("cargo:rustc-link-lib=user32");
+            println!("cargo:rustc-link-lib=strmiids");
+            println!("cargo:rustc-link-lib=mfuuid");
         }
 
         paths


### PR DESCRIPTION
Static linking with latest ffmpeg gives the following error: 
```
   avdevice.lib(dshow.o) : error LNK2001: unresolved external symbol IID_IBaseFilter
   avdevice.lib(dshow_filter.o) : error LNK2001: unresolved external symbol IID_IBaseFilter
   
   <snip>
   
   fatal error LNK1120: 32 unresolved externals
```
Adding the missing libraries to fix it.