### PR TITLE
Fix: failed to run custom build command on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -201,7 +201,8 @@ fn build() -> io::Result<()> {
     // Command's path is not relative to command's current_dir
     let configure_path = source_dir.join("configure");
     assert!(configure_path.exists());
-    let mut configure = Command::new(&configure_path);
+    let mut configure = Command::new("bash");
+    configure.arg(&configure_path);
     configure.current_dir(&source_dir);
 
     configure.arg(format!("--prefix={}", search().to_string_lossy()));


### PR DESCRIPTION
Failed to execute the configure binary directly in Windows.