### PR TITLE
fix: Cross compilation sysroot options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,21 @@ jobs:
     container: jrottenberg/ffmpeg:${{ matrix.ffmpeg_version }}-ubuntu
     strategy:
       matrix:
-        ffmpeg_version: ['3.3', '3.4', '4.0', '4.1', '4.2', '4.3', '4.4', '5.0', '5.1', '6.0', '6.1', '7.0']
+        ffmpeg_version:
+          [
+            "3.3",
+            "3.4",
+            "4.0",
+            "4.1",
+            "4.2",
+            "4.3",
+            "4.4",
+            "5.0",
+            "5.1",
+            "6.0",
+            "6.1",
+            "7.0",
+          ]
       fail-fast: false
     env:
       FEATURES: avcodec,avdevice,avfilter,avformat,postproc,swresample,swscale
@@ -20,9 +34,9 @@ jobs:
       - name: Install dependencies
         run: |
           apt update
-          apt install -y --no-install-recommends clang curl pkg-config
+          apt install -y --no-install-recommends clang curl pkg-config ca-certificates
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           override: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,10 @@ build-lib-x265             = ["build"]
 build-lib-avs              = ["build"]
 build-lib-xvid             = ["build"]
 
+# hardware accelleration
+build-videotoolbox =  ["build"]
+build-audiotoolbox =  ["build"]
+
 # protocols
 build-lib-smbclient = ["build"]
 build-lib-ssh       = ["build"]


### PR DESCRIPTION
There are a few ongoing issues with the current compilation which are fixed:

1. Ensured to provide a correct sysroot required for some of the clang compilers according to https://github.com/rust-lang/rust-bindgen/issues/1229
2. Automated the sysroot search both for ffmpeg build and bingen and ensured that the path is valid (new xcode version appends \n which breaks everythin)
3. Fixed some of the wronly passed parameters and enabled featuers for hardeward decoding on ioss