### PR TITLE
Added decklink build configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ build-lib-x264             = ["build"]
 build-lib-x265             = ["build"]
 build-lib-avs              = ["build"]
 build-lib-xvid             = ["build"]
+build-lib-decklink         = ["build"]
 
 # hardware accelleration
 build-videotoolbox = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@ extern crate num_cpus;
 extern crate pkg_config;
 
 use std::env;
+use std::ffi::OsString;
 use std::fmt::Write as FmtWrite;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Write};
@@ -529,6 +530,22 @@ fn build(sysroot: Option<&str>) -> io::Result<()> {
     enable!(configure, "BUILD_LIB_X265", "libx265");
     enable!(configure, "BUILD_LIB_AVS", "libavs");
     enable!(configure, "BUILD_LIB_XVID", "libxvid");
+
+    enable!(configure, "BUILD_LIB_DECKLINK", "decklink");
+    if env::var("CARGO_FEATURE_BUILD_LIB_DECKLINK").is_ok() {
+        match env::var_os("FFMPEG_DECKLINK_SDK_INCLUDE") {
+            Some(path) => {
+                let mut flags = OsString::from("--extra-cflags=-I");
+                flags.push(path);
+                configure.arg(flags);
+            }
+            None => {
+                eprintln!("Warning: missing environment variable FFMPEG_DECKLINK_SDK_INCLUDE, compilation may fail");
+                eprintln!("FFMPEG_DECKLINK_SDK_INCLUDE should be a path to decklink SDK (v12.9) include folder");
+                eprintln!("Please do not include space in path");
+            }
+        }
+    }
 
     // make sure to only enable related hw acceleration features for a correct
     // target os. This allows to leave allows cargo features enable and control


### PR DESCRIPTION
**Summary**

This Pull Request adds a new feature allowing ffmpeg to be built with [DeckLink](https://ffmpeg.org/ffmpeg-devices.html#decklink) capture card device support. It requires [Desktop Video SDK include files from Blackmagic](https://www.blackmagicdesign.com/support/family/capture-and-playback). At runtime, Blackmagic's Desktop Video drivers are still required.

> **NOTE** Currently, ffmpeg v7.1 only builds with SDK version 12.9 not above

**Changes**

* Feature called `build-lib-decklink` was added to cargo.toml triggering configure flag `--enable-decklink` during build script.
* An extra `FFMPEG_DECKLINK_SDK_INCLUDE` environment variable containing a path to DeckLink Desktop Video SDK include files adds this include folder as an extra C flag.

**Testing**

* Verified that `cargo build --features build-lib-decklink` completes without error on Linux Debian 12
* Verified that "decklink" is listed as an available video input device using ffmpeg-next