### PR TITLE
Fix #112 (unconditional march=native causes illegal instructions when distributing binaries) by adding control over -march/-mtune compiler flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ build-license-nonfree  = ["build"]
 build-license-version3 = ["build"]
 
 # misc
+build-portable = ["build"]
 build-drm   = ["build"]
 build-nvenc = ["build"]
 build-pic   = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -328,8 +328,38 @@ fn build(sysroot: Option<&str>) -> io::Result<()> {
             }
         }
     } else {
-        // tune the compiler for the host arhitecture
-        configure.arg("--extra-cflags=-march=native -mtune=native");
+        // Determine -march/-mtune flags for the compiler.
+        // Priority: env vars > build-portable feature > default (native)
+        println!("cargo:rerun-if-env-changed=FFMPEG_MARCH");
+        println!("cargo:rerun-if-env-changed=FFMPEG_MTUNE");
+
+        let march_env = env::var("FFMPEG_MARCH").ok();
+        let mtune_env = env::var("FFMPEG_MTUNE").ok();
+
+        let (march, mtune) = if march_env.is_some() || mtune_env.is_some() {
+            // Env vars take highest priority. Empty string means omit the flag.
+            (
+                march_env.unwrap_or_else(|| "native".to_string()),
+                mtune_env.unwrap_or_else(|| "native".to_string()),
+            )
+        } else if cfg!(feature = "build-portable") {
+            // Omit both flags so the compiler uses its baseline target.
+            (String::new(), String::new())
+        } else {
+            // Default: tune for the host architecture.
+            ("native".to_string(), "native".to_string())
+        };
+
+        let mut parts = Vec::new();
+        if !march.is_empty() {
+            parts.push(format!("-march={march}"));
+        }
+        if !mtune.is_empty() {
+            parts.push(format!("-mtune={mtune}"));
+        }
+        if !parts.is_empty() {
+            configure.arg(format!("--extra-cflags={}", parts.join(" ")));
+        }
     }
 
     if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {

--- a/build.rs
+++ b/build.rs
@@ -246,6 +246,26 @@ fn find_sysroot() -> Option<String> {
     None
 }
 
+/// Validate a CPU flag value (e.g. from FFMPEG_MARCH/FFMPEG_MTUNE) before passing
+/// it to the compiler, to prevent arbitrary string injection.
+fn validated_cpu_flag(var: &str, value: String) -> String {
+    if value.is_empty() {
+        return value; // omit the flag
+    }
+    let valid = !value.starts_with('-')
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '+' | '_'));
+    if !valid {
+        panic!(
+            "Invalid {} value {:?}: only ASCII letters, digits and '-._+' are allowed \
+             (e.g. native, x86-64-v3, armv8.2-a+crc)",
+            var, value
+        );
+    }
+    value
+}
+
 fn build(sysroot: Option<&str>) -> io::Result<()> {
     let source_dir = source();
     if cfg!(target_os = "windows") {
@@ -338,9 +358,16 @@ fn build(sysroot: Option<&str>) -> io::Result<()> {
 
         let (march, mtune) = if march_env.is_some() || mtune_env.is_some() {
             // Env vars take highest priority. Empty string means omit the flag.
+            // Validate the values to prevent arbitrary string injection.
             (
-                march_env.unwrap_or_else(|| "native".to_string()),
-                mtune_env.unwrap_or_else(|| "native".to_string()),
+                validated_cpu_flag(
+                    "FFMPEG_MARCH",
+                    march_env.unwrap_or_else(|| "native".to_string()),
+                ),
+                validated_cpu_flag(
+                    "FFMPEG_MTUNE",
+                    mtune_env.unwrap_or_else(|| "native".to_string()),
+                ),
             )
         } else if cfg!(feature = "build-portable") {
             // Omit both flags so the compiler uses its baseline target.


### PR DESCRIPTION
`build.rs` currently unconditionally adds `-march=native -mtune=native` which breaks for CI systems, since the FFmpeg build is tuned for the CI runner's CPU capabilities, which are often more advanced than the target systems.

I've added the `build-portable` feature flag, and updated the unconditional logic as follows:
  1. FFMPEG_MARCH / FFMPEG_MTUNE env vars (highest priority) — use their values; empty string omits the corresponding flag
  2. build-march-generic feature — omits both flags entirely for a portable build
  3. Default — uses native (backward compatible - I don't think native should be the default, but backwards compatibility seems preferable...)

This would fix #112 