### PR TITLE
fix(build): skip avfft.h for FFmpeg >= 8 (removed upstream)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1565,9 +1565,10 @@ fn main() {
         if ffmpeg_major_version < 5 {
             builder = builder.header(search_include(&include_paths, "libavcodec/vaapi.h"));
         }
-        let avfft_path = search_include(&include_paths, "libavcodec/avfft.h");
-        if std::path::Path::new(&avfft_path).exists() {
-            builder = builder.header(avfft_path);
+        if ffmpeg_major_version < 8 {
+            if let Some(avfft_path) = maybe_search_include(&include_paths, "libavcodec/avfft.h") {
+                builder = builder.header(avfft_path);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`libavcodec/avfft.h` was deprecated in FFmpeg 6.0 (lavc 60.25.100) and
removed in FFmpeg 8.0. Building against FFmpeg ≥ 8 could fail depending
on include path resolution behavior.

The previous implementation relied on an `exists()` guard after
`search_include`, which depended on fallback filesystem behavior rather
than explicit version semantics.

Fixes #117.

---

## Solution

- Gate inclusion of `libavcodec/avfft.h` on `ffmpeg_major_version < 8`
- Use the existing `maybe_search_include` helper for safe lookup
- Follow the same version-gating pattern already used for `vaapi.h`

This removes reliance on filesystem fallback behavior and makes the
intent explicit and consistent with existing header guards.

---

## Testing

Tested on macOS with FFmpeg 8.0.1 (Homebrew):

- `cargo build` succeeds
- `avfft.h` is not included in bindgen output
- No `avfft` symbols appear in generated `bindings.rs`
- No regressions observed

This preserves compatibility for users building against older FFmpeg
versions while ensuring clean builds with FFmpeg 8+.