### PR TITLE
Feed libavcodec/bsf.h to bindgen

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1563,6 +1563,11 @@ fn main() {
             .header(search_include(&include_paths, "libavcodec/dv_profile.h"))
             .header(search_include(&include_paths, "libavcodec/vorbis_parser.h"));
 
+        let bsf_path = search_include(&include_paths, "libavcodec/bsf.h");
+        if std::path::Path::new(&bsf_path).exists() {
+            builder = builder.header(bsf_path);
+        }
+
         if ffmpeg_major_version < 5 {
             builder = builder.header(search_include(&include_paths, "libavcodec/vaapi.h"));
         }


### PR DESCRIPTION
Figured I would submit this, despite there being a PR for the same thing from 2022. 

The `av_bsf_*` functions are not in the generated bindings. The bitstream-filter API has lived in its own header `libavcodec/bsf.h` since FFmpeg 4.3 and `avcodec.h` has never included it, so the symbols are missing from here.

Any issues with it let me know.